### PR TITLE
remove no-longer-needed hpow macro workaround

### DIFF
--- a/Ray/Analytic/Analytic.lean
+++ b/Ray/Analytic/Analytic.lean
@@ -20,9 +20,6 @@ import Ray.Misc.Topology
 ## Facts about analytic functions (general field case)
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Filter (atTop eventually_of_forall)
 open Function (curry uncurry)

--- a/Ray/Analytic/Holomorphic.lean
+++ b/Ray/Analytic/Holomorphic.lean
@@ -22,9 +22,6 @@ import Ray.Misc.Topology
 ## Basics about complex analytic (holomorphic) functions
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs exp I log)
 open Filter (atTop)
 open Metric (ball closedBall sphere isOpen_ball)

--- a/Ray/Analytic/Products.lean
+++ b/Ray/Analytic/Products.lean
@@ -22,9 +22,6 @@ We define convergence of infinite products, and show that uniform limits of prod
 analytic functions are analytic.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs exp log)
 open Filter (atTop)
 open Metric (ball closedBall sphere)

--- a/Ray/Analytic/Series.lean
+++ b/Ray/Analytic/Series.lean
@@ -18,9 +18,6 @@ import Ray.Tactic.Bound
 Uniformly convergent series of analytic functions have analytic limits.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs)
 open Filter (atTop)
 open Metric (ball closedBall sphere)

--- a/Ray/Analytic/Uniform.lean
+++ b/Ray/Analytic/Uniform.lean
@@ -23,9 +23,6 @@ import Ray.Tactic.Bound
 We show that uniformly convergence sequences of analytic functions have analytic limits.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs I)
 open Filter (atTop)
 open MeasureTheory.MeasureSpace (volume)
@@ -105,7 +102,7 @@ theorem cauchy_bound {f : ℂ → ℂ} {c : ℂ} {r : ℝ≥0} {d : ℝ≥0} {w 
         Complex.dist_eq, zr, le_refl]
     have zs := h z zb
     calc abs w ^ n / ↑r ^ n * (r⁻¹ * abs (f z))
-      _ = abs w ^ n * r⁻¹ ^ n * (r⁻¹ * abs (f z)) := by
+      _ = abs w ^ n * (r⁻¹ ^ n : ℝ≥0) * (r⁻¹ * abs (f z)) := by
         rw [div_eq_mul_inv, ← inv_pow, NNReal.coe_pow, NNReal.coe_inv]
       _ ≤ abs w ^ n * r⁻¹ ^ n * (r⁻¹ * d) := by bound
       _ = abs w ^ n * r⁻¹ ^ n * d * r⁻¹ := by ring

--- a/Ray/AnalyticManifold/AnalyticManifold.lean
+++ b/Ray/AnalyticManifold/AnalyticManifold.lean
@@ -34,9 +34,6 @@ Other things we show:
 4. A variety of other small things
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open ChartedSpace (chartAt)
 open Filter (eventually_of_forall)
 open Function (uncurry)

--- a/Ray/AnalyticManifold/Nontrivial.lean
+++ b/Ray/AnalyticManifold/Nontrivial.lean
@@ -35,9 +35,6 @@ From these, we have a variety of consequences, such as:
 6. Locally constant functions are constant on preconnected sets
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (abs)
 open Filter (Tendsto eventually_of_forall)

--- a/Ray/AnalyticManifold/OpenMapping.lean
+++ b/Ray/AnalyticManifold/OpenMapping.lean
@@ -26,9 +26,6 @@ unparameterized version, and specificaly our underlying workhorse is
 extentions of the flat versions lifted to charts.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (abs)
 open Filter (Tendsto eventually_of_forall)

--- a/Ray/Approx/Box.lean
+++ b/Ray/Approx/Box.lean
@@ -8,9 +8,6 @@ open Pointwise
 ## Complex interval arithmic (on top of 64-bit fixed point intervals)
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Set
 open scoped Real
 

--- a/Ray/Approx/Fixed.lean
+++ b/Ray/Approx/Fixed.lean
@@ -9,9 +9,6 @@ import Ray.Approx.UInt128
 ## 64-bit fixed point numbers
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Pointwise
 open Set
 open scoped Real

--- a/Ray/Approx/Float.lean
+++ b/Ray/Approx/Float.lean
@@ -4,9 +4,6 @@ import Mathlib.Data.Real.Basic
 ## `Float` extras
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Set
 open scoped Real
 

--- a/Ray/Approx/Int.lean
+++ b/Ray/Approx/Int.lean
@@ -4,9 +4,6 @@ import Mathlib.Data.Real.Basic
 ## `ℤ` facts
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 lemma abs_zpow {x : ℝ} {n : ℤ} : |x ^ n| = |x| ^ n := by
   induction' n with n n
   · simp only [Int.ofNat_eq_coe, zpow_coe_nat, abs_pow]

--- a/Ray/Approx/Interval.lean
+++ b/Ray/Approx/Interval.lean
@@ -9,9 +9,6 @@ open Pointwise
 ## 64-bit fixed point interval arithmetic
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Set
 open scoped Real
 

--- a/Ray/Approx/Nat.lean
+++ b/Ray/Approx/Nat.lean
@@ -9,9 +9,6 @@ import Ray.Approx.Bool
 ## `ℕ` facts
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 lemma Nat.add_sub_eq_sub_sub {m n k : ℕ} (nk : n ≤ k) : m + n - k = m - (k - n) := by
   rw [←Nat.sub_add_cancel nk]
   generalize k - n = a

--- a/Ray/Approx/UInt128.lean
+++ b/Ray/Approx/UInt128.lean
@@ -6,9 +6,6 @@ import Ray.Approx.UInt64
 ## `UInt128`: 128-bit integers
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 
 /-!
@@ -127,14 +124,14 @@ def UInt128.succ (x : UInt128) : UInt128 :=
     hi := x.hi + bif lo == 0 then 1 else 0 }
 
 lemma UInt128.toNat_succ {x : UInt128} (h : x.toNat ≠ 2^128-1) : x.succ.toNat = x.toNat+1 := by
-  have e : (2:UInt64)^64 = 0 := rfl
+  have e : (2:UInt64)^64 = 0 := by rfl
   by_cases ll : x.lo = (2:UInt64)^64-1
   · simp only [succ, ll, e, zero_sub, add_left_neg, beq_self_eq_true, cond_true]
     by_cases hh : x.hi = (2:UInt64)^64-1
     · simp only [toNat, hh, ll, ge_iff_le, ne_eq] at h; contrapose h; decide
     · simp only [UInt64.eq_iff_toNat_eq] at hh
       simp only [toNat, UInt64.toNat_add_one hh, add_mul, one_mul, UInt64.toNat_zero, add_zero, ll]
-      have c : (UInt64.toNat ((2:UInt64) ^ 64 - 1) : ℤ) = (2:ℤ)^64-1 := rfl
+      have c : (UInt64.toNat ((2:UInt64) ^ 64 - 1) : ℤ) = (2:ℤ)^64-1 := by rfl
       zify; rw [c]; ring
   · simp only [UInt64.eq_iff_toNat_eq] at ll
     simp only [toNat, succ, bif_eq_if, beq_iff_eq, UInt64.eq_iff_toNat_eq, UInt64.toNat_add_one ll,

--- a/Ray/Approx/UInt64.lean
+++ b/Ray/Approx/UInt64.lean
@@ -10,9 +10,6 @@ import Std.Data.Nat.Lemmas
 ## `UInt64` lemmas
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Qq
 
 attribute [pp_dot] UInt64.toNat
@@ -340,8 +337,8 @@ noncomputable instance : Coe UInt64 (ZMod UInt64.size) where
   simp only [toZMod, toNat, natCast_def, Fin.coe_ofNat_eq_mod, ZMod.nat_cast_mod]
 
 @[simp] lemma UInt64.toZMod_shiftLeft32 (x : UInt64) :
-    (x <<< 32 : ZMod UInt64.size) = x * (2 : ZMod _)^32 := by
-  have e : (2^32)^2 = UInt64.size := rfl
+    (x <<< 32 : ZMod UInt64.size) = x * (2 : ZMod UInt64.size)^32 := by
+  have e : (2^32)^2 = UInt64.size := by rfl
   rw [toZMod, UInt64.toNat_shiftLeft32, ←Nat.mod_mul_eq_mul_mod, e]
   simp only [ZMod.nat_cast_mod, Nat.cast_mul, toZMod_toNat, Nat.cast_pow, Nat.cast_ofNat]
 

--- a/Ray/Dynamics/Bottcher.lean
+++ b/Ray/Dynamics/Bottcher.lean
@@ -20,9 +20,6 @@ such that the defining equation always holds.  In particular, this means that
 since for higher potentials we choose roots arbitrarily.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (abs)
 open Filter (Tendsto atTop eventually_of_forall)

--- a/Ray/Dynamics/BottcherNear.lean
+++ b/Ray/Dynamics/BottcherNear.lean
@@ -28,9 +28,6 @@ One wart: we require not only that `f c` has a zero of order `d ≥ 2`, but also
 formulas, but is probably better to remove.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (exp log abs cpow)
 open Filter (Tendsto atTop)
@@ -230,7 +227,7 @@ Ignoring multiple values when taking `d`th roots, we can derive the infinite pro
 
 /-- Terms in our infinite product -/
 def term (f : ℂ → ℂ) (d n : ℕ) (z : ℂ) :=
-  g f d (f^[n] z) ^ (1 / d ^ (n + 1) : ℂ)
+  g f d (f^[n] z) ^ (1 / (d ^ (n + 1) : ℕ) : ℂ)
 
 /-- With `term` in hand, we can define Böttcher coordinates -/
 def bottcherNear (f : ℂ → ℂ) (d : ℕ) (z : ℂ) :=
@@ -321,7 +318,7 @@ theorem term_analytic (s : SuperNear f d t) : ∀ n, AnalyticOn ℂ (term f d n)
 theorem term_converges (s : SuperNear f d t) :
     ∀ n, z ∈ t → abs (term f d n z - 1) ≤ 1/2 * (1/2 : ℝ) ^ n := by
   intro n zt; rw [term]
-  trans 4 * abs (g f d (f^[n] z) - 1) * abs (1 / d ^ (n + 1) : ℂ)
+  trans 4 * abs (g f d (f^[n] z) - 1) * abs (1 / (d ^ (n + 1) : ℕ) : ℂ)
   · apply pow_small; · exact le_trans (s.gs (s.mapsTo n zt)) (by norm_num)
     · simp only [one_div, map_inv₀, Complex.abs_pow, Complex.abs_natCast, Nat.cast_pow]
       apply inv_le_one
@@ -331,7 +328,7 @@ theorem term_converges (s : SuperNear f d t) :
     have ps : abs (1 / (d:ℂ) ^ (n + 1) : ℂ) ≤ 1/2 * (1/2 : ℝ) ^ n := by
       have nn : (1/2:ℝ) * (1/2 : ℝ) ^ n = (1/2 : ℝ) ^ (n + 1) := (pow_succ _ _).symm
       rw [nn]; simp; apply inv_le_inv_of_le; bound; bound [s.dr2]
-    calc (4:ℝ) * abs (g f d (f^[n] z) - 1) * abs ((1:ℂ) / d ^ (n + 1) : ℂ)
+    calc (4:ℝ) * abs (g f d (f^[n] z) - 1) * abs ((1:ℂ) / (d ^ (n + 1) : ℕ) : ℂ)
       _ = (4:ℝ) * abs (g f d (f^[n] z) - 1) * abs ((1:ℂ) / (d:ℂ) ^ (n + 1) : ℂ) := by
         rw [Nat.cast_pow]
       _ ≤ 4 * (1 / 4) * (1 / 2 * (1 / 2 : ℝ) ^ n) := by bound

--- a/Ray/Dynamics/BottcherNearM.lean
+++ b/Ray/Dynamics/BottcherNearM.lean
@@ -21,9 +21,6 @@ contained within the chart, and (2) the local theory of `BottcherNear.lean` appl
 iteration sends `s.near` to `s.near`.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (exp log abs cpow)
 open Filter (Tendsto atTop eventually_of_forall)

--- a/Ray/Dynamics/Grow.lean
+++ b/Ray/Dynamics/Grow.lean
@@ -32,9 +32,6 @@ However, we know `bottcher` only locally near `a`, specifically on `s.near`.  If
   `bottcher (f^[n] (r x)) = bottcher (r x) ^ d ^ n = x ^ d ^ n`
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (abs)
 open Filter (Tendsto atTop eventually_of_forall)

--- a/Ray/Dynamics/Mandelbrot.lean
+++ b/Ray/Dynamics/Mandelbrot.lean
@@ -11,9 +11,6 @@ The rest of our proof works via `AnalyticManifold`s and other machinery.  Here w
 3. Thus, the Mandelbrot set and its complement are connected
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs)
 open Filter (Tendsto atTop)
 open RiemannSphere

--- a/Ray/Dynamics/Multibrot.lean
+++ b/Ray/Dynamics/Multibrot.lean
@@ -53,9 +53,6 @@ some example effective results that we prove:
 9. `bottcher d` is monic at `∞` (has derivative 1 there)
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs)
 open Filter (eventually_of_forall Tendsto atTop)
 open Function (uncurry)
@@ -1194,15 +1191,15 @@ theorem term_approx (d : ℕ) [Fact (2 ≤ d)] {c z : ℂ} (cb : exp 48 ≤ abs 
       _ ≥ 1 - abs (c * w ^ d) := by bound [Complex.abs_re_le_abs]
       _ ≥ 1 - 1 / 2 := by linarith
       _ ≥ 0 := by norm_num
-  · have dn : abs (-(1 / (d ^ (n + 1) : ℂ))) ≤ (1 / 2 : ℝ) ^ (n + 1) := by
+  · have dn : abs (-(1 / ((d ^ (n + 1) : ℕ) : ℂ))) ≤ (1 / 2 : ℝ) ^ (n + 1) := by
       simp only [Nat.cast_pow, one_div, map_neg_eq_map, map_inv₀, map_pow, Complex.abs_natCast,
         inv_pow]
       bound
-    have d1 : abs (-(1 / (d ^ (n + 1) : ℂ))) ≤ 1 := le_trans dn (by bound)
+    have d1 : abs (-(1 / ((d ^ (n + 1) : ℕ) : ℂ))) ≤ 1 := le_trans dn (by bound)
     refine le_trans (pow_small ?_ d1) ?_
     · rw [add_sub_cancel']; exact cw2
     · rw [add_sub_cancel']
-      calc 4 * abs (c * w ^ d) * abs (-(1 / (d ^ (n + 1) : ℂ)))
+      calc 4 * abs (c * w ^ d) * abs (-(1 / ((d ^ (n + 1) : ℕ) : ℂ)))
         _ ≤ 4 * (abs z)⁻¹ * (1/2 : ℝ) ^ (n + 1) := by bound
         _ ≤ 2 * (1/2 : ℝ) ^ n * (abs z)⁻¹ := by
           simp only [pow_succ, ←mul_assoc, mul_comm _ (1/2:ℝ)]; norm_num

--- a/Ray/Dynamics/Multiple.lean
+++ b/Ray/Dynamics/Multiple.lean
@@ -20,9 +20,6 @@ The proof proceeds in w.l.o.g. stages, reducing first from manifolds to `ℂ →
 the point to `0` and standardizing the leading coefficient to be 1.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (exp log abs cpow)
 open Filter (eventually_of_forall Tendsto atTop)
 open Function (curry uncurry)

--- a/Ray/Dynamics/Potential.lean
+++ b/Ray/Dynamics/Potential.lean
@@ -31,9 +31,6 @@ straightforward, but requires working over noncompact manifolds, using compactne
 of `s.potential`.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (exp log abs cpow)
 open Filter (Tendsto atTop eventually_of_forall)

--- a/Ray/Dynamics/Ray.lean
+++ b/Ray/Dynamics/Ray.lean
@@ -18,9 +18,6 @@ We still haven't defined Böttcher coordinates except near `a`, but their existe
 from bijectivity of `s.ray`; see `Bottcher.lean`.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (abs)
 open Filter (Tendsto atTop eventually_of_forall)

--- a/Ray/Hartogs/FubiniBall.lean
+++ b/Ray/Hartogs/FubiniBall.lean
@@ -15,9 +15,6 @@ We rewrite integration over the closed disk in polar coordinates, so that we can
 disk integrals to `intervalIntegral`s of `circleIntegral`s.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs arg exp I)
 open LinearMap (toMatrix_apply)
 open MeasureTheory

--- a/Ray/Hartogs/Hartogs.lean
+++ b/Ray/Hartogs/Hartogs.lean
@@ -44,9 +44,6 @@ References:
 2. https://www-users.cse.umn.edu/~garrett/m/complex/hartogs.pdf
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs exp I log)
 open Filter (atTop eventually_of_forall)
 open Function (curry uncurry)

--- a/Ray/Hartogs/Osgood.lean
+++ b/Ray/Hartogs/Osgood.lean
@@ -50,9 +50,6 @@ For a quick refresher on why the Cauchy power series works, for `c = 0`:
       = Σ_n w^n (2πi)⁻¹ ∫_C dz  z⁻¹^n * z⁻¹ * f z
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs exp I log)
 open Filter (atTop)
 open Function (curry uncurry)

--- a/Ray/Hartogs/Subharmonic.lean
+++ b/Ray/Hartogs/Subharmonic.lean
@@ -38,9 +38,6 @@ subharmonic functions that are bounded above and limsup bounded pointwise are li
 uniformly.  This is the key piece of measure theory needed for Hartogs' theorem.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs exp I log)
 open Filter (Tendsto liminf limsup atTop)
 open Function (uncurry)

--- a/Ray/Misc/Bounds.lean
+++ b/Ray/Misc/Bounds.lean
@@ -14,9 +14,6 @@ import Ray.Tactic.Bound
 ## Assorted bound lemmas
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Complex (abs exp log I)
 open Filter (atTop)

--- a/Ray/Misc/Continuation.lean
+++ b/Ray/Misc/Continuation.lean
@@ -18,9 +18,6 @@ but this may require a lot of machinery to cover manifolds in particular: the nL
 the existence of Riemannian metrics.
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Classical
 open Metric (ball isOpen_ball mem_ball mem_ball_self)
 open Set

--- a/Ray/Misc/Pow.lean
+++ b/Ray/Misc/Pow.lean
@@ -4,9 +4,6 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Complex
 ## `Complex.pow` and `pow` interact nicely
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 theorem pow_mul_nat {z w : ℂ} {n : ℕ} : (z ^ w) ^ n = z ^ (w * n) := by
   by_cases z0 : z = 0
   · rw [z0]

--- a/Ray/Tactic/Bound.lean
+++ b/Ray/Tactic/Bound.lean
@@ -32,9 +32,6 @@ References:
 2. Lean 4 metaprogramming book: https://github.com/leanprover-community/lean4-metaprogramming-book
 -/
 
--- Remove once https://github.com/leanprover/lean4/issues/2220 is fixed
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Complex (abs)
 open Parser
 open Lean Elab Meta Term Mathlib.Tactic Mathlib.Meta Syntax


### PR DESCRIPTION
Removes the local macro declarations that were intended as a workaround for https://github.com/leanprover/lean4/issues/2220, which has now been fixed.

To get things to typecheck after this change:
* adds some type ascriptions
* changes some `rfl` proofs to `by rfl`